### PR TITLE
fix "strlen(): Argument #1 ($string) must be of type string, null given"

### DIFF
--- a/src/encryption/src/Commands/KeyGenerateCommand.php
+++ b/src/encryption/src/Commands/KeyGenerateCommand.php
@@ -70,7 +70,7 @@ class KeyGenerateCommand extends HyperfCommand
         $currentKey = $this->config->get('app.key')
             ?: $this->config->get('encryption.key');
 
-        if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
+        if (strlen($currentKey ?: '') !== 0 && (! $this->confirmToProceed())) {
             return false;
         }
 


### PR DESCRIPTION
Was happening on PHP 8.3 although i think this error starts from php 8.1?